### PR TITLE
[WIP] Reuse the existing token in client_credentials flow

### DIFF
--- a/lib/doorkeeper/oauth/client_credentials/creator.rb
+++ b/lib/doorkeeper/oauth/client_credentials/creator.rb
@@ -3,10 +3,9 @@ module Doorkeeper
     class ClientCredentialsRequest
       class Creator
         def call(client, scopes, attributes = {})
-          AccessToken.create(attributes.merge(
-            application_id: client.id,
-            scopes: scopes.to_s
-          ))
+          AccessToken.find_or_create_for(
+            client, nil, scopes, attributes[:expires_in],
+            attributes[:use_refresh_token])
         end
       end
     end

--- a/spec/lib/oauth/client_credentials/creator_spec.rb
+++ b/spec/lib/oauth/client_credentials/creator_spec.rb
@@ -11,8 +11,35 @@ class Doorkeeper::OAuth::ClientCredentialsRequest
       end.to change { Doorkeeper::AccessToken.count }.by(1)
     end
 
+    context "when reuse_access_token is true" do
+      before do
+        allow(Doorkeeper.configuration).to receive(:reuse_access_token).and_return(true)
+      end
+
+      it 'returns the existing valid token when one exists' do
+        existing_token = subject.call(client, scopes)
+        existing_token_count = Doorkeeper::AccessToken.count
+        result = subject.call(client, scopes)
+        expect(Doorkeeper::AccessToken.count).to eq(existing_token_count)
+        expect(result).to eq(existing_token)
+      end
+    end
+
+    context "when reuse_access_token is false" do
+      before do
+        allow(Doorkeeper.configuration).to receive(:reuse_access_token).and_return(false)
+      end
+
+      it 'returns the existing valid token when one exists' do
+        subject.call(client, scopes)
+        expect do
+          subject.call(client, scopes)
+        end.to change { Doorkeeper::AccessToken.count }.by(1)
+      end
+    end
+
     it 'returns false if creation fails' do
-      expect(Doorkeeper::AccessToken).to receive(:create).and_return(false)
+      expect(Doorkeeper::AccessToken).to receive(:find_or_create_for).and_return(false)
       created = subject.call(client, scopes)
       expect(created).to be_falsey
     end

--- a/spec/lib/oauth/token_request_spec.rb
+++ b/spec/lib/oauth/token_request_spec.rb
@@ -1,6 +1,12 @@
 require 'spec_helper_integration'
 
 module Doorkeeper::OAuth
+  describe ClientCredentialsRequest do
+    subject do
+      # TODO: Do we need something here too?
+    end
+  end
+
   describe TokenRequest do
     let :application do
       scopes = double(all: ['public'])


### PR DESCRIPTION
This is a work in progress. To avoid polluting the original gems Pull Requests I will change the Pull Request's base branch when this is done.

Fixes issue 661: https://github.com/doorkeeper-gem/doorkeeper/issues/661
